### PR TITLE
Fixed naming convention error with RST_NN instructions

### DIFF
--- a/src/JumpInstructionSet.cpp
+++ b/src/JumpInstructionSet.cpp
@@ -29,8 +29,8 @@ bool JumpInstructionSet::execute(uint8_t opcode, CPU& cpu) {
         case CALL_NZ_a16:
             call_nz_a16(cpu);
             return true;
-        case RST_00:
-            rst_00(cpu);
+        case RST_00H:
+            rst_00H(cpu);
             return true;
         case RET_Z:
             ret_z(cpu);
@@ -47,8 +47,8 @@ bool JumpInstructionSet::execute(uint8_t opcode, CPU& cpu) {
         case CALL_a16:
             call_a16(cpu);
             return true;
-        case RST_08:
-            rst_08(cpu);
+        case RST_08H:
+            rst_08H(cpu);
             return true;
         case RET_NC:
             ret_nc(cpu);
@@ -59,8 +59,8 @@ bool JumpInstructionSet::execute(uint8_t opcode, CPU& cpu) {
         case CALL_NC_a16:
             call_nc_a16(cpu);
             return true;
-        case RST_10:
-            rst_10(cpu);
+        case RST_10H:
+            rst_10H(cpu);
             return true;
         case RET_C:
             ret_c(cpu);
@@ -74,23 +74,23 @@ bool JumpInstructionSet::execute(uint8_t opcode, CPU& cpu) {
         case CALL_C_a16:
             call_c_a16(cpu);
             return true;
-        case RST_18:
-            rst_18(cpu);
+        case RST_18H:
+            rst_18H(cpu);
             return true;
-        case RST_20:
-            rst_20(cpu);
+        case RST_20H:
+            rst_20H(cpu);
             return true;
         case JP_HL:
             jp_hl(cpu);
             return true;
-        case RST_28:
-            rst_28(cpu);
+        case RST_28H:
+            rst_28H(cpu);
             return true;
-        case RST_30:    
-            rst_30(cpu);
+        case RST_30H:    
+            rst_30H(cpu);
             return true;
-        case RST_38:    
-            rst_38(cpu);
+        case RST_38H:    
+            rst_38H(cpu);
             return true;
         default:
             return false; // Opcode not handled by JumpInstructionSet
@@ -142,7 +142,7 @@ void JumpInstructionSet::call_nz_a16(CPU& cpu) {
     // Example: cpu.call_nz_a16();
 }
 
-void JumpInstructionSet::rst_00(CPU& cpu) {
+void JumpInstructionSet::rst_00H(CPU& cpu) {
     // Placeholder for RST 00 functionality
     // Example: cpu.rst_00();
 }
@@ -172,7 +172,7 @@ void JumpInstructionSet::call_a16(CPU& cpu) {
     // Example: cpu.call_a16();
 }
 
-void JumpInstructionSet::rst_08(CPU& cpu) {
+void JumpInstructionSet::rst_08H(CPU& cpu) {
     // Placeholder for RST 08 functionality
     // Example: cpu.rst_08();
 }
@@ -192,7 +192,7 @@ void JumpInstructionSet::call_nc_a16(CPU& cpu) {
     // Example: cpu.call_nc_a16();
 }
 
-void JumpInstructionSet::rst_10(CPU& cpu) {
+void JumpInstructionSet::rst_10H(CPU& cpu) {
     // Placeholder for RST 10 functionality
     // Example: cpu.rst_10();
 }
@@ -217,12 +217,12 @@ void JumpInstructionSet::call_c_a16(CPU& cpu) {
     // Example: cpu.call_c_a16();
 }
 
-void JumpInstructionSet::rst_18(CPU& cpu) {
+void JumpInstructionSet::rst_18H(CPU& cpu) {
     // Placeholder for RST 18 functionality
     // Example: cpu.rst_18();
 }
 
-void JumpInstructionSet::rst_20(CPU& cpu) {
+void JumpInstructionSet::rst_20H(CPU& cpu) {
     // Placeholder for RST 20 functionality
     // Example: cpu.rst_20();
 }
@@ -232,17 +232,17 @@ void JumpInstructionSet::jp_hl(CPU& cpu) {
     // Example: cpu.jp_hl();
 }
 
-void JumpInstructionSet::rst_28(CPU& cpu) {
+void JumpInstructionSet::rst_28H(CPU& cpu) {
     // Placeholder for RST 28 functionality
     // Example: cpu.rst_28();
 }
 
-void JumpInstructionSet::rst_30(CPU& cpu) {
+void JumpInstructionSet::rst_30H(CPU& cpu) {
     // Placeholder for RST 30 functionality
     // Example: cpu.rst_30();
 }
 
-void JumpInstructionSet::rst_38(CPU& cpu) {
+void JumpInstructionSet::rst_38H(CPU& cpu) {
     // Placeholder for RST 38 functionality
     // Example: cpu.rst_38();
 }

--- a/src/include/JumpInstructionSet.h
+++ b/src/include/JumpInstructionSet.h
@@ -13,27 +13,27 @@
 #define JP_NZ_a16 0xC2
 #define JP_a16 0xC3
 #define CALL_NZ_a16 0xC4
-#define RST_00 0xC7
+#define RST_00H 0xC7
 #define RET_Z 0xC8
 #define RET 0xC9
 #define JP_Z_a16 0xCA
 #define CALL_Z_a16 0xCC
 #define CALL_a16 0xCD
-#define RST_08 0xCF
+#define RST_08H 0xCF
 #define RET_NC 0xD0
 #define JP_NC_a16 0xD2
 #define CALL_NC_a16 0xD4
-#define RST_10 0xD7
+#define RST_10H 0xD7
 #define RET_C 0xD8
 #define RETI 0xD9
 #define JP_C_a16 0xDA
 #define CALL_C_a16 0xDC
-#define RST_18 0xDF
-#define RST_20 0xE7
+#define RST_18H 0xDF
+#define RST_20H 0xE7
 #define JP_HL 0xE9
-#define RST_28 0xEF
-#define RST_30 0xF7
-#define RST_38 0xFF
+#define RST_28H 0xEF
+#define RST_30H 0xF7
+#define RST_38H 0xFF
 
 class JumpInstructionSet : public InstructionSet {
 public:
@@ -49,27 +49,27 @@ private:
     void jp_nz_a16(CPU& cpu);
     void jp_a16(CPU& cpu);
     void call_nz_a16(CPU& cpu);
-    void rst_00(CPU& cpu);
+    void rst_00H(CPU& cpu);
     void ret_z(CPU& cpu);
     void ret(CPU& cpu);
     void jp_z_a16(CPU& cpu);
     void call_z_a16(CPU& cpu);
     void call_a16(CPU& cpu);
-    void rst_08(CPU& cpu);
+    void rst_08H(CPU& cpu);
     void ret_nc(CPU& cpu);
     void jp_nc_a16(CPU& cpu);
     void call_nc_a16(CPU& cpu);
-    void rst_10(CPU& cpu);
+    void rst_10H(CPU& cpu);
     void ret_c(CPU& cpu);
     void reti(CPU& cpu);
     void jp_c_a16(CPU& cpu);
     void call_c_a16(CPU& cpu);
-    void rst_18(CPU& cpu);
-    void rst_20(CPU& cpu);
+    void rst_18H(CPU& cpu);
+    void rst_20H(CPU& cpu);
     void jp_hl(CPU& cpu);
-    void rst_28(CPU& cpu);
-    void rst_30(CPU& cpu);
-    void rst_38(CPU& cpu);
+    void rst_28H(CPU& cpu);
+    void rst_30H(CPU& cpu);
+    void rst_38H(CPU& cpu);
 };
 
 #endif // JUMP_INSTRUCTION_SET_H


### PR DESCRIPTION
RST_NN instructions were set as RST_NN instead of RST_NNH to denote hexadecimal. 